### PR TITLE
Mention should_not in related projects in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ Run in simulator mode (it just prints the changes to the screen)
 
     should_clean -d DIRECTORY -s
 
+## Related Projects
+
+* [should_not](https://github.com/should-not/should_not): a gem to enforce that specs in RSpec and MiniTest do not begin with "should."
+
 ## Contributing
 
 1. Fork it


### PR DESCRIPTION
I've mentioned should_clean as a related project in the README for [should_not](https://github.com/should-not/should_not), a gem I wrote to enforce that specs do not begin with should.  Would you mind linking back to should_not as a related project?  Thanks!
